### PR TITLE
serve ws remote over http

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,12 +91,19 @@ exports.init = function (sbot, config) {
     ]
   ])
 
+  http.createServer(function (req, res) {
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.end(ms.stringify())
+  }).listen(3377)
+
   var close = ms.server(function (stream) {
     var manifest = sbot.getManifest()
     var rpc = muxrpc({}, manifest)(sbot, stream.auth)
     rpc.id = toId(stream.remote)
     pull(stream, rpc.createStream(), stream)
   })
+
+  
 
   //close when the server closes.
   sbot.close.hook(function (fn, args) {


### PR DESCRIPTION
This change is necessary for minbase/minbay to be able to find and register a local websocket remote. 

If there's a better way to do this, suggestions welcome below.