### PR TITLE
support encrypted blobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   },
   "dependencies": {
     "emoji-server": "^1.0.0",
-    "multiblob-http": "^0.2.0",
+    "multiblob-http": "^0.3.0",
     "multiserver": "^1.2.0",
     "muxrpc": "^6.3.3",
+    "pull-box-stream": "^1.0.13",
     "ssb-ref": "^2.3.0",
     "stack": "^0.1.0"
   },


### PR DESCRIPTION
this adds support for decrypting private blobs. I had originally wanted to do the decryption key inside the `#` fragment, because it's not actually sent to the server, but then my thinking for the whole websbot/lite client changed. I don't think we can do private groups (or any interesting private stuff) without having private indexes - necessitating a sbot server that is _in the know_... turns out, this also means private blobs become very easy to implement...

merging this: https://github.com/ssbc/ssb-markdown/pull/21 and possibly making the markdown renderer in your favorite ssb client more permissive and you will be able to render private blobs!