### PR TITLE
refactor to use a secret-stack transport 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,7 @@
-var MultiServer = require('multiserver')
 var WS = require('multiserver/plugins/ws')
-var SHS = require('multiserver/plugins/shs')
 var http = require('http')
-var muxrpc = require('muxrpc')
 var pull = require('pull-stream')
 var JSONApi = require('./json-api')
-
-var cap =
-  new Buffer('1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s=', 'base64')
-
-function toSodiumKeys(keys) {
-  return {
-    publicKey:
-      new Buffer(keys.public.replace('.ed25519',''), 'base64'),
-    secretKey:
-      new Buffer(keys.private.replace('.ed25519',''), 'base64'),
-  }
-}
 
 var READ_AND_ADD = [ //except for add, of course
   'get',
@@ -45,18 +30,9 @@ var READ_AND_ADD = [ //except for add, of course
 
 exports.name = 'ws'
 exports.version = require('./package.json').version
-exports.manifest = {
-  getAddress: 'sync'
-}
-
-function toId(id) {
-  if (typeof id !== 'string') {
-    return '@' + id.toString('base64') + '.ed25519' // isn't this available somewhere else?
-  } else throw new Error('toId() called on string. todo: clean this your mess.')
-}
+exports.manifest = {}
 
 exports.init = function (sbot, config) {
-
   var port
   if(config.ws)
     port = config.ws.port
@@ -64,54 +40,42 @@ exports.init = function (sbot, config) {
     port = 1024+(~~(Math.random()*(65536-1024)))
 
   var layers = []
-  var server = http.createServer(JSONApi(sbot, layers)).listen(port)
+  var server, ws_server
 
-  function _auth (id, cb) {
-    sbot.friends.get({source: sbot.id, dest: toId(id)}, function (err, follows) {
-      if(err) return cb(err)
-      else if(follows) cb(null, {allow: READ_AND_ADD, deny: null})
-      else cb()
+  function createServer (instance) {
+    if(server) return server
+    server = http.createServer(JSONApi(sbot, layers)).listen(port+instance)
+    ws_server = WS({
+      server: server, port: port, host: config.host || 'localhost'
     })
+    return server
   }
 
-  var ms = MultiServer([
-    [
-      WS({server: server, port: port, host: config.host || 'localhost'}),
-      SHS({
-        keys: toSodiumKeys(config.keys),
-        appKey: (config.caps && new Buffer(config.caps.shs, "base64")) || cap,
-        auth: function (id, cb) {
-          sbot.auth(toId(id), function (err, allowed) {
-            if(err || allowed) cb(err, allowed)
-            else _auth(id, cb)
-          })
-        },
-        timeout: config.timeout
-      })
-    ]
-  ])
-
-  var close = ms.server(function (stream) {
-    var manifest = sbot.getManifest()
-    var rpc = muxrpc({}, manifest)(sbot, stream.auth)
-    rpc.id = toId(stream.remote)
-    pull(stream, rpc.createStream(), stream)
+  sbot.auth.hook(function (fn, args) {
+    var id = args[0]
+    var cb = args[1]
+    fn(id, function (err, value) {
+      if(value === true)
+        sbot.friends.get({source: sbot.id, dest: toId(id)}, function (err, follows) {
+          if(err) return cb(err)
+          else if(follows) cb(null, {allow: READ_AND_ADD, deny: null})
+          else cb(null, true)
+        })
+      else
+        cb(err, value)
+    })
   })
 
-  //close when the server closes.
-  sbot.close.hook(function (fn, args) {
-    close()
-    fn.apply(this, args)
+  sbot.multiserver.transport(function (instance) {
+    console.log('create ws server'.toUpperCase())
+    createServer(instance)
+    return ws_server
   })
 
   return {
-    getAddress: function () {
-      return ms.stringify()
-    },
     use: function (handler) {
       layers.push(handler)
     }
-
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "emoji-server": "^1.0.0",
-    "multiblob-http": "^0.4.1",
-    "multiserver": "^1.2.0",
+    "multiblob-http": "^0.4.2",
+    "multiserver": "^1.12.0",
     "muxrpc": "^6.3.3",
     "pull-box-stream": "^1.0.13",
     "ssb-ref": "^2.3.0",


### PR DESCRIPTION
this depends on https://github.com/ssbc/secret-stack/pull/21

with this merged, and linking the above secret-stack update, getAddress returns all supported addresses!
```
> sbot getAddress
"net:localhost:8008~shs:EMovhfIrFk4NihAKnRNhrfRaqIhBv1Wj8pTxJNgvCCY=;ws://localhost:8989~shs:EMovhfIrFk4NihAKnRNhrfRaqIhBv1Wj8pTxJNgvCCY="
```
with this server, you could connect use either net _or_ websockets, and since both are returned in the address, it's pretty obvious that both are supported.

@evbogue I think this may break the way you are currently doing liteclient - I remember talking about it but can't find the code now?