### PR TITLE
Bind to specified host and support multiple servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "emoji-server": "^1.0.0",
     "multiblob-http": "^0.4.2",
     "multiserver": "^1.13.5",
+    "multiserver-scopes": "^1.0.0",
     "muxrpc": "^6.3.3",
     "pull-box-stream": "^1.0.13",
     "ssb-ref": "^2.3.0",


### PR DESCRIPTION
Currently the http server created by ssb-ws binds to all available IP
addresses, because no host is specified to `listen()`. This is not
desireable, because users expect the host they configured to be used.
(either via config.connections.incoming.ws.host, config.ws.host or
config.host)

This also support auto-selecting a host by specifying a scope and no
host. If none of incoming.ws.host, incoming.ws.scope, condig.ws.host or config.host
is specified, host defaults to 'localhost'.

Binding to localhost by default instead of to all available IPs breaks backward
compatibility. However, this can be fixed in ssb-config and secret-stack
by creating a default ws incoming with `host: '::'`, or better, by defaulting config.host to '::'

This also adds support for multiple http/websocket servers. Users can
configure multiple ws incomings with different scopes and transforms,
for example, ws/noauth for localhost only and ws/shs in the LAN.