### PR TITLE
Remove special permissions from ssb-ws

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
+  - 6
+  - 8
+  - 10

--- a/index.js
+++ b/index.js
@@ -1,42 +1,14 @@
 var WS = require('multiserver/plugins/ws')
-var http = require('http')
-var pull = require('pull-stream')
 var JSONApi = require('./json-api')
-var scopes = require('multiserver-scopes')
-
-var READ_AND_ADD = [ //except for add, of course
-  'get',
-  'getLatest',
-  'createLogStream',
-  'createUserStream',
-
-  'createHistoryStream',
-  'getAddress',
-
-  'links',
-
-  'blobs.add',
-  'blobs.size',
-  'blobs.has',
-  'blobs.get',
-  'blobs.changes',
-  'blobs.createWants',
-
-  'add',
-
-  'query.read',
-  'links2.read'
-]
 
 exports.name = 'ws'
 exports.version = require('./package.json').version
 exports.manifest = {}
 
 exports.init = function (sbot, config) {
-  var port, host
+  var port
   if(config.ws) {
     port = config.ws.port
-    host = config.ws.host || config.host
   }
   if(!port)
     port = 1024+(~~(Math.random()*(65536-1024)))
@@ -51,23 +23,14 @@ exports.init = function (sbot, config) {
     var id = args[0]
     var cb = args[1]
     fn(id, function (err, value) {
-      if(value === true)
-        sbot.friends.get({source: sbot.id, dest: toId(id)}, function (err, follows) {
-          if(err) return cb(err)
-          else if(follows) cb(null, {allow: READ_AND_ADD, deny: null})
-          else cb(null, true)
-        })
-      else
-        cb(err, value)
+      cb(err, value)
     })
   })
-  var c = 0
   sbot.multiserver.transport({
     name: 'ws',
     create: function (config) {
       var _host = config.host || 'localhost'
       var _port = config.port || port
-      //debug('listening on host=%s port=%d', _host, _port)
       return WS(Object.assign({
         port: _port, host: _host,
         handler: config.http !== false ? handlers : no_handler
@@ -81,5 +44,3 @@ exports.init = function (sbot, config) {
     }
   }
 }
-
-

--- a/index.js
+++ b/index.js
@@ -19,13 +19,6 @@ exports.init = function (sbot, config) {
   function no_handler (req, res, next) {
     next(new Error('ssb-ws:web sockets only'))
   }
-  sbot.auth.hook(function (fn, args) {
-    var id = args[0]
-    var cb = args[1]
-    fn(id, function (err, value) {
-      cb(err, value)
-    })
-  })
   sbot.multiserver.transport({
     name: 'ws',
     create: function (config) {

--- a/package.json
+++ b/package.json
@@ -11,13 +11,17 @@
     "emoji-server": "^1.0.0",
     "multiblob-http": "^0.4.2",
     "multiserver": "^3.0.2",
-    "multiserver-scopes": "^1.0.0",
-    "muxrpc": "^6.3.3",
     "pull-box-stream": "^1.0.13",
+    "pull-stream": "^3.6.9",
     "ssb-ref": "^2.3.0",
     "stack": "^0.1.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "ssb-client": "^4.7.1",
+    "ssb-config": "^3.0.0",
+    "ssb-server": "^14.1.6",
+    "tape": "^4.10.1"
+  },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,44 @@
+const crypto = require('crypto')
+const ssbClient = require('ssb-client')
+const ssbConfig = require('ssb-config/inject')
+const ssbServer = require('ssb-server')
+  .use(require('ssb-server/plugins/master'))
+  .use(require('../'))
+const test = require('tape')
+
+const caps = {
+  shs: crypto.randomBytes(32).toString('base64')
+}
+
+const customConfig = {
+  caps,
+  connections: {
+    incoming: {
+      ws: [{
+        scope: ["public", "local", "device"],
+        port: 9000,
+        transform: "shs",
+      }]
+    }
+  }
+}
+
+const config = ssbConfig('testnet', customConfig)
+const server = ssbServer(config)
+
+test('example configuration works', function (t) {
+  t.plan(1);
+
+  setImmediate(() =>
+    ssbClient(server.keys, {
+      caps,
+      remote: server.getAddress(),
+      manifest: {}
+    }, (err, api) => {
+      t.error(err)
+      api.close()
+      server.close()
+      t.end()
+    })
+  )
+});


### PR DESCRIPTION
It's unclear to me why these were added to the ssb-ws interface, but
they seem that they may allow local peers to query all messages
(including decrypted private messages) and should probably be
implemented somewhere else if necessary. This commit also removes unused
variables, which makes it less difficult to grok the code.