### PR TITLE
Throw error on init if ssb-blobs is missing

### DIFF
--- a/blobs.js
+++ b/blobs.js
@@ -8,6 +8,10 @@ var zeros = new Buffer(24); zeros.fill(0)
 module.exports = function (sbot, opts) {
   var prefix = opts.prefix
 
+  if (!sbot.blobs) {
+    throw new Error("ssb-ws requires the ssb-blobs plugin, please add to your ssb config")
+  }
+
   var handler = BlobsHttp(sbot.blobs, prefix, {size: false, transform: function (q) {
     if(q.unbox && /\.boxs$/.test(q.unbox)) {
       var key = new Buffer(q.unbox.replace(/\s/g, '+'), 'base64')


### PR DESCRIPTION
multiblob-http will not work if ssb-blobs is not loaded. Currently it will appear to work then crash after a blob is requested. To save users the headache of figuring out why their server is crashing throw an error on load if ssb-blobs isn't installed.

Related: https://github.com/ssbc/multiblob-http/issues/5